### PR TITLE
fix(#4): Weird look on flutter 3.24 beta

### DIFF
--- a/flutter/mesh/README.md
+++ b/flutter/mesh/README.md
@@ -14,21 +14,21 @@ classes to render Free-Form mesh gradients.
 
 ## What? 🤨
 
-A free form mesh gradient means that the gradient is not limited to a linear or radial shape, but can be defined by a custom mesh of points. Each point in the mesh can have its own color and position. This gives developers the flexibility to create unique and complex visual effects in their Flutter applications. They can be used to enhance the visual appeal of UI elements and backgrounds.
+A free-form mesh gradient means that the gradient is not limited to a linear or radial shape but can be defined by a custom mesh of points. Each point in the mesh can have its own color and position. This gives developers the flexibility to create unique and complex visual effects in their Flutter applications. They can be used to enhance the visual appeal of UI elements and backgrounds.
 
-This package brings this to Flutter apps.
+This package brings this capability to Flutter apps.
 
-## Are you using O'Mesh? Let me know
+## Are you using O'Mesh? Let me know.
 
 If there is a chance of you using O'Mesh, do it 😉. If you do, I would love to see it in action. Let me know where and how you are using it via my socials: [Twitter](https://twitter.com/reNotANumber) and [LinkedIn](https://www.linkedin.com/in/renancaraujo/).
 
-## Docs and resources 📚
+## Documentation and resources 📚
 
-Best resources to get the best out of O'Mesh:
+The best resources to get the most out of O'Mesh:
 
 - [API Docs](https://pub.dev/documentation/mesh/latest/) on pub.dev;
 - [My Twitter](https://twitter.com/reNotANumber) where I post some examples;
-- More to come;
+- More to come.
 
 ## Getting Started 🚀
 
@@ -37,7 +37,8 @@ On your Flutter App project, install the package via the following command:
 ```sh
 flutter pub add mesh
 ```
-Most user-facing APIs are under the following import:
+
+Most user-facing APIs are found under the following import:
 
 ```dart
 import 'package:mesh/mesh.dart';
@@ -409,7 +410,7 @@ It may be caused by an issue with the Impeller rendering engine. Learn the possi
 
 This may be caused by too many triangles in your mesh
 
-The number of triangles in a mesh can be descriobed by `(width-1) * (height-1) * (tessellationFactor ^ 2) * 2`.
+The number of triangles in a mesh can be described by `(width-1) * (height-1) * (tessellationFactor ^ 2) * 2`.
 
 The default tessellation factor is 12, consider lowering that value for small sized containers or for
 meshes with too many vertices. See below the visual impacts of a change in the tessellation factor.
@@ -450,15 +451,15 @@ In other words:
 
 ---
 
-Still have issues, feel free to report in the issues tab on [Github](https://github.com/renancaraujo/omesh).
+If you still have issues, feel free to report them in the Issues tab on [Github](https://github.com/renancaraujo/omesh).
 
 ---
 
 ## Thanks
 
-This work wouldn't be possible if not by some special people
+This work wouldn't be possible without some special people:
 
-- Luke Pighetti for nerdsniping me about this a year ago
+- Luke Pighetti for nerd-sniping me about this a year ago
 - Lots of mathematicians behind the theories that sustain this package
 - The Dart and Flutter folks at Google
 - My Mom that gave birth to me

--- a/flutter/mesh/example/lib/examples/custom_animation.dart
+++ b/flutter/mesh/example/lib/examples/custom_animation.dart
@@ -121,6 +121,13 @@ class _CustomAnimationState extends State<CustomAnimation>
     });
 
   @override
+  void dispose() {
+    super.dispose();
+
+    controller.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return SizedBox(
       height: 500,

--- a/flutter/mesh/example/lib/main.dart
+++ b/flutter/mesh/example/lib/main.dart
@@ -69,7 +69,7 @@ class Main extends StatefulWidget {
 }
 
 class _MainState extends State<Main> {
-  Example exampleScreen = Example.values.first;
+  Example exampleScreen = Example.intrinsicAnimation;
 
   @override
   Widget build(BuildContext context) {

--- a/flutter/mesh/example/lib/main.dart
+++ b/flutter/mesh/example/lib/main.dart
@@ -69,7 +69,7 @@ class Main extends StatefulWidget {
 }
 
 class _MainState extends State<Main> {
-  Example exampleScreen = Example.intrinsicAnimation;
+  Example exampleScreen = Example.values.first;
 
   @override
   Widget build(BuildContext context) {

--- a/flutter/mesh/lib/src/widgets/omesh_gradient.dart
+++ b/flutter/mesh/lib/src/widgets/omesh_gradient.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_shaders/flutter_shaders.dart';
 import 'package:mesh/mesh.dart';
 
 /// A [Widget] that renders a multi-color gradient over a
@@ -247,9 +246,24 @@ class AnimatedOMeshGradient extends StatelessWidget {
   }
 }
 
+/// A class responsible for loading and caching the fragment shader
+/// responsible for interpolation the colors of the mesh.
+///
+/// This class is used internally by the [OMeshGradient]
+/// and [AnimatedOMeshGradient] and should be used directly only
+/// if you want to render a mesn on canvas  directly (eg. by using
+/// [OMeshRectPaint]).
+/// 
+/// Should be loaded via [OMeshShaderProvider.load] and disposed
+/// when no longer needed.
+/// 
+/// Avoid sharing instances of this class between different
+/// mesh gradient areas.
 class OMeshShaderProvider {
   OMeshShaderProvider._(this._program);
 
+  /// Loads the shader provider. It will resolve after
+  /// the [FragmentProgram] is loaded.
   static Future<OMeshShaderProvider> load() async {
     return OMeshShaderProvider._(await _loadProgram());
   }
@@ -275,15 +289,17 @@ class OMeshShaderProvider {
     }
   }
 
-  FragmentProgram _program;
+  final FragmentProgram _program;
 
   final Map<int, FragmentShader> _shaders = {};
 
+  /// Returns the shader for the given patch index.
   FragmentShader getShaderFor(int index) {
-    return _shaders[index] =
-        _shaders[index] ?? _program.fragmentShader();
+    return _shaders[index] = _shaders[index] ?? _program.fragmentShader();
   }
 
+
+  /// Disposes the shader provider and all the shaders.
   void dispose() {
     for (final shader in _shaders.values) {
       shader.dispose();

--- a/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
+++ b/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
@@ -12,7 +12,7 @@ import 'package:mesh/mesh.dart';
 /// Useful to render mesh gradients outside of widget contexts, such as
 /// custom paints, flame engine components, and render objects.
 class OMeshRectPaint {
-  /// Creates a new [OMeshRectPaint] with the given [shaderProvider] 
+  /// Creates a new [OMeshRectPaint] with the given [shaderProvider]
   /// and [meshRect],
   OMeshRectPaint({
     required this.shaderProvider,
@@ -178,6 +178,11 @@ class OMeshRectPaint {
       rect: rect,
     );
 
+    canvas.saveLayer(
+      rect,
+      Paint(),
+    );
+
     // Draw each patch one at a time.
     for (final tuple in patches.reversed.indexed) {
       final (patchIndex, patch) = tuple;
@@ -236,6 +241,7 @@ class OMeshRectPaint {
         paintShader,
       );
     }
+    canvas.restore();
   }
 }
 

--- a/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
+++ b/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:cached_value/cached_value.dart';
 import 'package:flutter/rendering.dart'
-    show BlendMode, Canvas, Color, Paint, Rect, ValueGetter;
+    show BlendMode, Canvas, Color, Paint, Rect;
 import 'package:flutter_shaders/flutter_shaders.dart';
 import 'package:mesh/internal_stuff.dart';
 import 'package:mesh/mesh.dart';
@@ -12,7 +12,8 @@ import 'package:mesh/mesh.dart';
 /// Useful to render mesh gradients outside of widget contexts, such as
 /// custom paints, flame engine components, and render objects.
 class OMeshRectPaint {
-  /// Creates a new [OMeshRectPaint] with the given [shaderProvider], [meshRect],
+  /// Creates a new [OMeshRectPaint] with the given [shaderProvider] 
+  /// and [meshRect],
   OMeshRectPaint({
     required this.shaderProvider,
     required OMeshRect meshRect,
@@ -23,7 +24,7 @@ class OMeshRectPaint {
         _tessellation = tessellation,
         _meshRect = meshRect;
 
-
+  /// The shader provider instance associated with this paint.
   final OMeshShaderProvider shaderProvider;
 
   /// Enable compatibility mode for impeller runtime.
@@ -156,7 +157,6 @@ class OMeshRectPaint {
       );
     }
 
-
     // some shorthan helpers
     final mw = meshRect.width;
     final mh = meshRect.height;
@@ -177,8 +177,6 @@ class OMeshRectPaint {
       normalizedVertices: textureVertices,
       rect: rect,
     );
-
-    
 
     // Draw each patch one at a time.
     for (final tuple in patches.reversed.indexed) {
@@ -232,17 +230,12 @@ class OMeshRectPaint {
         impellerCompatibilityMode: impellerCompatibilityMode,
       );
 
-      
-
       canvas.drawVertices(
         vertices,
         BlendMode.srcOver,
         paintShader,
       );
-      
     }
-
-
   }
 }
 


### PR DESCRIPTION
## Description

This makes each mesh segment have its own instance of FragmentShader, reusing the program across the entire application.

This is a breaking change for people using `OMeshRectPaint` directly.

## (Required) Link to the issue

Link to the issue related to this contribution #4