### PR TITLE
feat: straighten public API after performance optmization

### DIFF
--- a/flutter/mesh/analysis_options.yaml
+++ b/flutter/mesh/analysis_options.yaml
@@ -203,6 +203,5 @@ linter:
     - use_string_in_part_of_directives
     - use_super_parameters
     - use_test_throws_matchers
-    - use_to_and_as_if_applicable
     - valid_regexps
     - void_checks

--- a/flutter/mesh/example/lib/examples/custom_animation.dart
+++ b/flutter/mesh/example/lib/examples/custom_animation.dart
@@ -190,7 +190,7 @@ class _CustomAnimationState extends State<CustomAnimation>
 }
 
 extension on OVertex {
-  OVertex to(OVertex b, double t) => OVertex.lerp(this, b, t);
+  OVertex to(OVertex b, double t) => lerpTo(b, t);
 }
 
 extension on Color? {

--- a/flutter/mesh/example/lib/examples/custom_animation.dart
+++ b/flutter/mesh/example/lib/examples/custom_animation.dart
@@ -9,7 +9,7 @@ class CustomAnimation extends StatefulWidget {
 // Some syntax-sugarring
 
 extension on OVertex {
-  OVertex to(OVertex b, double t) => OVertex.lerp(this, b, t);
+  OVertex to(OVertex b, double t) => lerpTo(b, t);
 }
 
 extension on Color? {

--- a/flutter/mesh/lib/src/data/omesh_rect.dart
+++ b/flutter/mesh/lib/src/data/omesh_rect.dart
@@ -104,7 +104,7 @@ class OMeshRect {
       smoothColors: b.smoothColors,
       vertices: [
         for (int i = 0; i < b.vertices.length; i++)
-          OVertex.lerp(a.vertices[i], b.vertices[i], t),
+          a.vertices[i].lerpTo(b.vertices[i], t),
       ],
       colors: [
         for (int i = 0; i < b.colors.length; i++)

--- a/flutter/mesh/lib/src/data/overtex.dart
+++ b/flutter/mesh/lib/src/data/overtex.dart
@@ -1,187 +1,127 @@
 import 'dart:math';
 import 'dart:ui' as ui;
 
-/// A vertex with bezier control points.
-///
-/// The control points are used to create bezier curves between vertices.
-///
-/// The widget will infet the position of the control points if they are not
-/// provided.
+/// A vertex with `x` and `y` components.
 ///
 /// Use shorthand initializers to create a new [OVertex] via one of the
 /// following extensions:
-/// - `(0.0, 0.0).v`
-///   => `OVertex(0.0, 0.0)`
-/// - `(0, 0).v`
-///   => `OVertex(0.0, 0.0)`
-/// - `(0.5, 0.5).v.bezier(north: (0.5, 0.4).v)`
-///   => `OVertex.bezier(position: OVertex(0.5, 0.5), north: OVertex(0.5, 0.5))`
+/// - `(0.0, 0.0).v` => `OVertex(0.0, 0.0)`
+/// - `(0, 0).v`  => `OVertex(0.0, 0.0)`
 ///
-/// It is also possible to convert an [ui.Offset] or to an [OVertex]
-/// via the following extensions:
+/// An [OVertex] can be created from instances of other classes:
 /// - `Offset(0.0, 0.0).toOVertex()`
+///
+/// See also:
+/// - [BezierOVertex], a vertex with bezier control points for each direction
+///  on a rectangular mesh.
 class OVertex {
   /// Creates a new [OVertex] with the given [x] and [y] values.
-  factory OVertex(double x, double y) {
-    return OVertex.zero()
-      ..dx = x
-      ..dy = y;
-  }
+  OVertex(this.x, this.y);
 
   /// Creates a new zeroed and empty [OVertex].
   OVertex.zero()
-      : northCp = null,
-        eastCp = null,
-        southCp = null,
-        westCp = null,
-        dx = 0,
-        dy = 0;
+      : x = 0.0,
+        y = 0.0;
 
   /// Creates a new [OVertex] from an [ui.Offset].
-  factory OVertex.offset(ui.Offset offset) {
-    return OVertex.zero()
-      ..dx = offset.dx
-      ..dy = offset.dy;
-  }
+  OVertex.offset(ui.Offset offset)
+      : x = offset.dx,
+        y = offset.dy;
 
   /// Creates a new [OVertex] with the same `x` and `y` values.
-  factory OVertex.all(double xy) {
-    return OVertex.zero()
-      ..dx = xy
-      ..dy = xy;
-  }
+  OVertex.all(double xy)
+      : x = xy,
+        y = xy;
 
   /// Creates a copy of the given [OVertex].
-  factory OVertex.copy(OVertex other) {
-    return OVertex.zero()
-      ..dx = other.dx
-      ..dy = other.dy
-      ..northCp = other.northCp
-      ..eastCp = other.eastCp
-      ..southCp = other.southCp
-      ..westCp = other.westCp;
-  }
+  OVertex.copy(OVertex other)
+      : x = other.x,
+        y = other.y;
 
   /// Linearly interpolates between two [OVertex] objects.
   factory OVertex.lerp(OVertex a, OVertex b, double t) {
-    final n = ui.Offset.lerp(a.northCp, b.northCp, t);
-    final e = ui.Offset.lerp(a.eastCp, b.eastCp, t);
-    final s = ui.Offset.lerp(a.southCp, b.southCp, t);
-    final w = ui.Offset.lerp(a.westCp, b.westCp, t);
-
-    return a._lerp(b, t)
-      ..northCp = n
-      ..eastCp = e
-      ..southCp = s
-      ..westCp = w;
+    return a.lerpTo(b, t);
   }
 
-  /// Creates a new [OVertex] with bezier control points.
+  /// Creates an [BezierOVertex] with the given control points.
   factory OVertex.bezier({
     required OVertex position,
-    ui.Offset? north,
-    ui.Offset? east,
-    ui.Offset? south,
-    ui.Offset? west,
+    OVertex? north,
+    OVertex? east,
+    OVertex? south,
+    OVertex? west,
   }) {
-    return OVertex.zero()
-      ..dx = position.dx
-      ..dy = position.dy
-      ..northCp = north
-      ..eastCp = east
-      ..southCp = south
-      ..westCp = west;
+    return BezierOVertex(
+      position.x,
+      position.y,
+      north: north,
+      east: east,
+      south: south,
+      west: west,
+    );
   }
 
   /// The x component of the offset.
   ///
-  /// The y component is given by [dy].
-  double dx;
+  /// The y component is given by [y].
+  double x;
 
   /// The y component of the offset.
   ///
-  /// The x component is given by [dx].
-  double dy;
-
-  /// Compute the euclidian distance between [other] and this.
-  double distanceTo(OVertex other) {
-    return sqrt(pow(other.dx - dx, 2) + pow(other.dy - dy, 2));
-  }
-
-  /// The bezier control point for the north direction.
-  ui.Offset? northCp;
-
-  /// The bezier control point for the east direction.
-  ui.Offset? eastCp;
-
-  /// The bezier control point for the south direction.
-  ui.Offset? southCp;
-
-  /// The bezier control point for the west direction.
-  ui.Offset? westCp;
-
-  OVertex _lerp(OVertex to, double t) {
-    return OVertex.zero()
-      ..dx = ((to.dx - dx) / t) + dx
-      ..dy = ((to.dy - dy) / t) + dy;
-  }
+  /// The x component is given by [x].
+  double y;
 
   /// Create a copy of this OVertex.
   OVertex clone() => OVertex.copy(this);
 
   /// Converts this [OVertex] to an [ui.Offset].
-  ui.Offset toOffset() => ui.Offset(dx, dy);
+  ui.Offset toOffset() => ui.Offset(x, y);
+
+  /// Linearly interpolate between two [OVertex] objects.
+  OVertex lerpTo(OVertex to, double t) {
+    return OVertex.zero()
+      ..x = ((to.x - x) / t) + x
+      ..y = ((to.y - y) / t) + y;
+  }
+
+  /// Compute the euclidian distance between [other] and this.
+  double distanceTo(OVertex other) {
+    return sqrt(pow(other.x - x, 2) + pow(other.y - y, 2));
+  }
 
   /// Unary negation operator.
   OVertex operator -() => clone()
-    ..dx = -dx
-    ..dy = -dy;
+    ..x = -x
+    ..y = -y;
 
   /// Binary addition operator.
-  OVertex operator +(ui.Offset other) => clone()
-    ..dx += other.dx
-    ..dy += other.dy;
+  OVertex operator +(OVertex other) => clone()
+    ..x += other.x
+    ..y += other.y;
 
   /// Binary subtraction operator.
-  OVertex operator -(ui.Offset other) => clone()
-    ..dx -= other.dx
-    ..dy -= other.dy;
+  OVertex operator -(OVertex other) => clone()
+    ..x -= other.x
+    ..y -= other.y;
 
   /// Binary multiplication operator.
   OVertex operator *(double scale) => clone()
-    ..dx /= scale
-    ..dy /= scale;
+    ..x /= scale
+    ..y /= scale;
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
-      other is OVertex &&
-      dx == other.dx &&
-      dy == other.dy &&
-      northCp == other.northCp &&
-      eastCp == other.eastCp &&
-      southCp == other.southCp &&
-      westCp == other.westCp;
+      other is OVertex && x == other.x && y == other.y;
 
   @override
-  int get hashCode => Object.hash(dx, dy, northCp, eastCp, southCp, westCp);
+  int get hashCode => Object.hash(x, y);
 }
 
 /// Extension on [ui.Offset] to convert it to an [OVertex].
 extension OffsetToOVertex on ui.Offset {
-  /// Converts an [ui.Offset] to an [OVertex] with
-  /// the given control points.
-  OVertex toOVertex({
-    ui.Offset? northCp,
-    ui.Offset? eastCp,
-    ui.Offset? southCp,
-    ui.Offset? westCp,
-  }) =>
-      OVertex.offset(this)
-        ..northCp = northCp
-        ..eastCp = eastCp
-        ..southCp = southCp
-        ..westCp = westCp;
+  /// Converts an [ui.Offset] to an [OVertex]
+  OVertex toOVertex() => OVertex.offset(this);
 }
 
 /// Extension on [double] to convert it to an [OVertex].
@@ -196,22 +136,178 @@ extension NumNumToOVertex on (num, num) {
   OVertex get v => OVertex($1.toDouble(), $2.toDouble());
 }
 
+/// A vertex with bezier control points.
+///
+/// It extends [OVertex] and adds control points for each
+/// direction on a rectangular mesh.
+///
+/// The control points are used to create bezier curves between vertices.
+///
+/// The widget will infer the position of the control points if
+/// they are not provided.
+///
+/// Use shorthand initializers to create a new [BezierOVertex] via one of the
+/// following extensions:
+/// - `(0.0, 0.0).v.bezier(north: (0.0, 0.0).v)`
+///   => `BezierOVertex(0.0, 0.0, north: OVertex(0.0, 0.0))`
+///
+/// An [BezierOVertex] can be created from instances of other classes:
+/// - `Offset(0.0, 0.0).toOVertex().bezier(south: (0.0, 0.0).v)`
+class BezierOVertex extends OVertex {
+  /// Creates a new [BezierOVertex] with the given [x] and [y] values,
+  /// and control points for each direction.
+  BezierOVertex(
+    super.x,
+    super.y, {
+    this.north,
+    this.east,
+    this.south,
+    this.west,
+  });
+
+  /// Creates a new zeroed and empty [BezierOVertex].
+  BezierOVertex.zero()
+      : north = null,
+        east = null,
+        south = null,
+        west = null,
+        super.zero();
+
+  /// Creates a new [BezierOVertex] from an [ui.Offset].
+  BezierOVertex.offset(
+    super.offset, {
+    this.north,
+    this.east,
+    this.south,
+    this.west,
+  }) : super.offset();
+
+  /// Creates a new [BezierOVertex] with the same `x` and `y` values.
+  BezierOVertex.all(
+    super.xy, {
+    this.north,
+    this.east,
+    this.south,
+    this.west,
+  }) : super.all();
+
+  /// Creates a new [BezierOVertex] from an [OVertex].
+  BezierOVertex.oVertex(
+    OVertex vertex, {
+    this.north,
+    this.east,
+    this.south,
+    this.west,
+  }) : super(vertex.x, vertex.y);
+
+  /// Creates a copy of the given [BezierOVertex].
+  BezierOVertex.copy(BezierOVertex super.other)
+      : north = other.north,
+        east = other.east,
+        south = other.south,
+        west = other.west,
+        super.copy();
+
+  /// The bezier control point for the north direction.
+  OVertex? north;
+
+  /// The bezier control point for the east direction.
+  OVertex? east;
+
+  /// The bezier control point for the south direction.
+  OVertex? south;
+
+  /// The bezier control point for the west direction.
+  OVertex? west;
+
+  @override
+  BezierOVertex clone() => BezierOVertex.copy(this);
+
+  /// Converts this [BezierOVertex] to an [OVertex].
+  OVertex toOVertex() => OVertex(x, y);
+
+  @override
+  BezierOVertex lerpTo(OVertex to, double t) {
+    final lerped = BezierOVertex.zero()
+      ..x = ((to.x - x) / t) + x
+      ..y = ((to.y - y) / t) + y;
+    if (to is! BezierOVertex) {
+      return lerped;
+    }
+    return lerped
+      ..north = north?.lerpTo(to.north!, t)
+      ..east = east?.lerpTo(to.east!, t)
+      ..south = south?.lerpTo(to.south!, t)
+      ..west = west?.lerpTo(to.west!, t);
+  }
+
+  @override
+  BezierOVertex operator -() => clone()
+    ..x = -x
+    ..y = -y
+    ..north = north != null ? -north! : null
+    ..east = east != null ? -east! : null
+    ..south = south != null ? -south! : null
+    ..west = west != null ? -west! : null;
+
+  @override
+  BezierOVertex operator +(OVertex other) => clone()
+    ..x += other.x
+    ..y += other.y
+    ..north = north != null ? north! + other : null
+    ..east = east != null ? east! + other : null
+    ..south = south != null ? south! + other : null
+    ..west = west != null ? west! + other : null;
+
+  @override
+  BezierOVertex operator -(OVertex other) => clone()
+    ..x -= other.x
+    ..y -= other.y
+    ..north = north != null ? north! - other : null
+    ..east = east != null ? east! - other : null
+    ..south = south != null ? south! - other : null
+    ..west = west != null ? west! - other : null;
+
+  @override
+  BezierOVertex operator *(double scale) => clone()
+    ..x *= scale
+    ..y *= scale
+    ..north = north != null ? north! * scale : null
+    ..east = east != null ? east! * scale : null
+    ..south = south != null ? south! * scale : null
+    ..west = west != null ? west! * scale : null;
+
+  @override
+  bool operator ==(Object other) =>
+      other is BezierOVertex &&
+      x == other.x &&
+      y == other.y &&
+      north == other.north &&
+      east == other.east &&
+      south == other.south &&
+      west == other.west;
+
+  @override
+  int get hashCode => Object.hash(x, y, north, east, south, west);
+}
+
 /// Extension on [OVertex] to create a new [OVertex] with bezier control points.
 extension BezierizeOVertex on OVertex {
   /// Returns a new [OVertex] with the given control points.
   ///
   /// This overrides the control points of the current [OVertex],
   /// being `null` if not provided.
-  OVertex bezier({
+  BezierOVertex bezier({
     OVertex? north,
     OVertex? east,
     OVertex? south,
     OVertex? west,
-  }) {
-    return this
-      ..eastCp = east == null ? null : ui.Offset(east.dx, east.dy)
-      ..northCp = north == null ? null : ui.Offset(north.dx, north.dy)
-      ..southCp = south == null ? null : ui.Offset(south.dx, south.dy)
-      ..westCp = west == null ? null : ui.Offset(west.dx, west.dy);
-  }
+  }) =>
+      BezierOVertex.oVertex(
+        this,
+        north: north,
+        east: east,
+        south: south,
+        west: west,
+      );
 }

--- a/flutter/mesh/lib/src/data/overtex.dart
+++ b/flutter/mesh/lib/src/data/overtex.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'dart:ui' as ui;
 
 /// A vertex with `x` and `y` components.
@@ -23,25 +22,20 @@ class OVertex {
       : x = 0.0,
         y = 0.0;
 
-  /// Creates a new [OVertex] from an [ui.Offset].
-  OVertex.offset(ui.Offset offset)
-      : x = offset.dx,
-        y = offset.dy;
-
   /// Creates a new [OVertex] with the same `x` and `y` values.
   OVertex.all(double xy)
       : x = xy,
         y = xy;
 
+  /// Creates a new [OVertex] from an [ui.Offset].
+  OVertex.offset(ui.Offset offset)
+      : x = offset.dx,
+        y = offset.dy;
+
   /// Creates a copy of the given [OVertex].
   OVertex.copy(OVertex other)
       : x = other.x,
         y = other.y;
-
-  /// Linearly interpolates between two [OVertex] objects.
-  factory OVertex.lerp(OVertex a, OVertex b, double t) {
-    return a.lerpTo(b, t);
-  }
 
   /// Creates an [BezierOVertex] with the given control points.
   factory OVertex.bezier({
@@ -80,13 +74,8 @@ class OVertex {
   /// Linearly interpolate between two [OVertex] objects.
   OVertex lerpTo(OVertex to, double t) {
     return OVertex.zero()
-      ..x = ((to.x - x) / t) + x
-      ..y = ((to.y - y) / t) + y;
-  }
-
-  /// Compute the euclidian distance between [other] and this.
-  double distanceTo(OVertex other) {
-    return sqrt(pow(other.x - x, 2) + pow(other.y - y, 2));
+      ..x = x * (1.0 - t) + to.x * t
+      ..y = y * (1.0 - t) + to.y * t;
   }
 
   /// Unary negation operator.
@@ -106,8 +95,8 @@ class OVertex {
 
   /// Binary multiplication operator.
   OVertex operator *(double scale) => clone()
-    ..x /= scale
-    ..y /= scale;
+    ..x *= scale
+    ..y *= scale;
 
   /// Check if two vectors are the same.
   @override
@@ -229,8 +218,8 @@ class BezierOVertex extends OVertex {
   @override
   BezierOVertex lerpTo(OVertex to, double t) {
     final lerped = BezierOVertex.zero()
-      ..x = ((to.x - x) / t) + x
-      ..y = ((to.y - y) / t) + y;
+      ..x = x * (1.0 - t) + to.x * t
+      ..y = y * (1.0 - t) + to.y * t;
     if (to is! BezierOVertex) {
       return lerped;
     }

--- a/flutter/mesh/lib/src/internal_stuff/rendered_omesh_rect.dart
+++ b/flutter/mesh/lib/src/internal_stuff/rendered_omesh_rect.dart
@@ -119,25 +119,25 @@ class RenderedOVertex {
         final (:relativeVertex, :guide) = relativeInfo;
 
         final ogRotationRad =
-            _angleBetween(guide, ui.Offset(position.dx, position.dy));
+            _angleBetween(guide, ui.Offset(position.x, position.y));
         final rotationRad = _angleBetween(
-            ui.Offset(relativeVertex.dx, relativeVertex.dy),
-            ui.Offset(position.dx, position.dy));
+            ui.Offset(relativeVertex.x, relativeVertex.y),
+            ui.Offset(position.x, position.y));
         final rotationRadLerp = _radiusLerp(rotationRad, ogRotationRad, 0.8);
 
         final distance = position.distanceTo(relativeVertex);
 
         final rotatedRelativeVertex = ui.Offset(
-          position.dx + cos(rotationRadLerp) * distance * distanceFactor,
-          position.dy + sin(rotationRadLerp) * distance * distanceFactor,
+          position.x + cos(rotationRadLerp) * distance * distanceFactor,
+          position.y + sin(rotationRadLerp) * distance * distanceFactor,
         );
 
         return rotatedRelativeVertex;
       }
-      return ui.Offset(position.dx, position.dy);
+      return ui.Offset(position.x, position.y);
     }
 
-    final ui.Offset positionOffset = ui.Offset(position.dx, position.dy);
+    final ui.Offset positionOffset = ui.Offset(position.x, position.y);
 
     final north = inferCp(
       cp: position.northCp,
@@ -180,7 +180,7 @@ class RenderedOVertex {
     );
 
     return RenderedOVertex(
-      p: ui.Offset(position.dx, position.dy),
+      p: ui.Offset(position.x, position.y),
       north: north,
       east: east,
       south: south,
@@ -246,8 +246,8 @@ extension on OVertex {
   _DeNormalizedOVertex denormalize(Rect rect) {
     return _DeNormalizedOVertex(
       OVertex(
-        dx * rect.width + rect.left,
-        dy * rect.height + rect.top,
+        x * rect.width + rect.left,
+        y * rect.height + rect.top,
       )
         ..eastCp = eastCp?.withinV(rect)
         ..northCp = northCp?.withinV(rect)

--- a/flutter/mesh/lib/src/internal_stuff/tessellated_mesh.dart
+++ b/flutter/mesh/lib/src/internal_stuff/tessellated_mesh.dart
@@ -10,7 +10,7 @@ import 'package:mesh/internal_stuff.dart';
 class TessellatedMesh {
   TessellatedMesh({
     required int tessellation,
-  })  : _vertexData = Float32List((tessellation * tessellation) * 24);
+  }) : _vertexData = Float32List((tessellation * tessellation) * 24);
 
   final Float32List _vertexData;
 
@@ -26,8 +26,16 @@ class TessellatedMesh {
   }) {
     final lengthInF32 = _vertexData.length ~/ 2;
     final offsetInBytes = lengthInF32 * 4;
-    final verticesTriangles = Float32List.view(_vertexData.buffer, 0, lengthInF32);
-    final textureTriangles = Float32List.view(_vertexData.buffer, offsetInBytes, lengthInF32);
+    final verticesTriangles = Float32List.view(
+      _vertexData.buffer,
+      0,
+      lengthInF32,
+    );
+    final textureTriangles = Float32List.view(
+      _vertexData.buffer,
+      offsetInBytes,
+      lengthInF32,
+    );
 
     _writeTriangles(
       size,

--- a/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
+++ b/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
@@ -174,7 +174,7 @@ class OMeshRectPaint {
     );
     final textureMesh = RenderedOMeshRect(
       mesh: meshRect,
-      normalizedVertices: textureVertices,
+      normalizedVerticesOverride: textureVertices,
       rect: rect,
     );
 
@@ -215,10 +215,14 @@ class OMeshRectPaint {
           ..setFloatUniforms(
             (s) => s
               ..setSize(rect.size)
-              ..setFloats(
-                  [textureVertices[index00].x, textureVertices[index00].y])
-              ..setFloats(
-                  [textureVertices[index11].x, textureVertices[index11].y])
+              ..setFloats([
+                textureVertices[index00].x,
+                textureVertices[index00].y,
+              ])
+              ..setFloats([
+                textureVertices[index11].x,
+                textureVertices[index11].y,
+              ])
               ..setColorsWide(colors)
               ..setBools(biases)
               ..setColorSpace(meshRect.colorSpace)

--- a/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
+++ b/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
@@ -216,9 +216,9 @@ class OMeshRectPaint {
             (s) => s
               ..setSize(rect.size)
               ..setFloats(
-                  [textureVertices[index00].dx, textureVertices[index00].dy])
+                  [textureVertices[index00].x, textureVertices[index00].y])
               ..setFloats(
-                  [textureVertices[index11].dx, textureVertices[index11].dy])
+                  [textureVertices[index11].x, textureVertices[index11].y])
               ..setColorsWide(colors)
               ..setBools(biases)
               ..setColorSpace(meshRect.colorSpace)

--- a/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
+++ b/flutter/mesh/lib/src/widgets/omesh_rect_paint.dart
@@ -233,11 +233,11 @@ class OMeshRectPaint {
 
       final vertices =
           tessellatedMeshCache.value.getTessellatedVerticesForPatch(
-        size: rect.size,
         cornerIndices: patchIndices,
         verticesMesh: verticesMesh,
         textureMesh: textureMesh,
         tessellation: tessellation,
+        impellerCompatibilityMode: impellerCompatibilityMode,
       );
 
       canvas.drawVertices(

--- a/flutter/mesh/pubspec.yaml
+++ b/flutter/mesh/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/renancaraujo/omesh/tree/main/flutter/mesh
 issue_tracker: https://github.com/renancaraujo/omesh/issues
 homepage: https://github.com/renancaraujo/omesh
 documentation: https://github.com/renancaraujo/omesh/tree/main/flutter/mesh
-topics: [mesh-gradients, flutter, shaders, ui, gradient]
+topics: [mesh-gradients, flutter, shaders, mesh, gradient]
 screenshots:
   - description: 'This screenshot shows a usage example of the dependabot_gen CLI tool.'
     path: doc/assets/preview.png

--- a/flutter/mesh/test/src/data/overtex_test.dart
+++ b/flutter/mesh/test/src/data/overtex_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mesh/mesh.dart';
 
@@ -10,40 +8,24 @@ void main() {
         final vertex = OVertex.zero();
         expect(vertex.x, 0.0);
         expect(vertex.y, 0.0);
-        expect(vertex.northCp, isNull);
-        expect(vertex.eastCp, isNull);
-        expect(vertex.southCp, isNull);
-        expect(vertex.westCp, isNull);
       });
 
       test('OVertex', () {
         final vertex = OVertex(1, 2);
         expect(vertex.x, 1.0);
         expect(vertex.y, 2.0);
-        expect(vertex.northCp, isNull);
-        expect(vertex.eastCp, isNull);
-        expect(vertex.southCp, isNull);
-        expect(vertex.westCp, isNull);
       });
 
       test('OVertex.offset', () {
         final vertex = OVertex.offset(const Offset(1, 2));
         expect(vertex.x, 1.0);
         expect(vertex.y, 2.0);
-        expect(vertex.northCp, isNull);
-        expect(vertex.eastCp, isNull);
-        expect(vertex.southCp, isNull);
-        expect(vertex.westCp, isNull);
       });
 
       test('OVertex.all', () {
         final vertex = OVertex.all(1);
         expect(vertex.x, 1.0);
         expect(vertex.y, 1.0);
-        expect(vertex.northCp, isNull);
-        expect(vertex.eastCp, isNull);
-        expect(vertex.southCp, isNull);
-        expect(vertex.westCp, isNull);
       });
 
       test('OVertex.copy', () {
@@ -51,50 +33,26 @@ void main() {
         final copy = OVertex.copy(vertex);
         expect(copy.x, 1.0);
         expect(copy.y, 2.0);
-        expect(copy.northCp, isNull);
-        expect(copy.eastCp, isNull);
-        expect(copy.southCp, isNull);
-        expect(copy.westCp, isNull);
       });
     });
 
     group('equals', () {
       test('==', () {
-        final vertex1 = OVertex(1, 2)
-          ..northCp = const ui.Offset(1, 2)
-          ..eastCp = const ui.Offset(1, 2)
-          ..southCp = const ui.Offset(1, 2)
-          ..westCp = const ui.Offset(1, 2);
-        final vertex2 = OVertex(1, 2)
-          ..northCp = const ui.Offset(1, 2)
-          ..eastCp = const ui.Offset(1, 2)
-          ..southCp = const ui.Offset(1, 2)
-          ..westCp = const ui.Offset(1, 2);
+        final vertex1 = OVertex(1, 2);
+        final vertex2 = OVertex(1, 2);
         expect(vertex1, vertex2);
       });
 
       test('!=', () {
-        final vertex1 = OVertex(1, 2)
-          ..northCp = const ui.Offset(1, 2)
-          ..eastCp = const ui.Offset(1, 2)
-          ..southCp = const ui.Offset(1, 2)
-          ..westCp = const ui.Offset(1, 2);
-        final vertex2 = OVertex(2, 1)
-          ..northCp = const ui.Offset(1, 2)
-          ..eastCp = const ui.Offset(1, 2)
-          ..southCp = const ui.Offset(1, 2)
-          ..westCp = const ui.Offset(1, 2);
+        final vertex1 = OVertex(1, 2);
+        final vertex2 = OVertex(2, 1);
         expect(vertex1, isNot(vertex2));
       });
     });
 
     group('clone', () {
       test('clone', () {
-        final vertex = OVertex(1, 2)
-          ..northCp = const ui.Offset(1, 2)
-          ..eastCp = const ui.Offset(1, 2)
-          ..southCp = const ui.Offset(1, 2)
-          ..westCp = const ui.Offset(1, 2);
+        final vertex = OVertex(1, 2);
         final clone = vertex.clone();
         expect(clone, vertex);
         expect(clone, isNot(same(vertex)));
@@ -110,6 +68,24 @@ void main() {
       });
     });
 
+    group('lerpTo', () {
+      test('lerpTo', () {
+        final vertex = OVertex(1, 2);
+        final lerp = vertex.lerpTo(OVertex(2, 4), 0.5);
+        expect(lerp.x, 1.5);
+        expect(lerp.y, 3.0);
+
+        final lerpEp1 = vertex.lerpTo(OVertex(2, 4), -0.5);
+
+        expect(lerpEp1.x, 0.5);
+        expect(lerpEp1.y, 1.0);
+
+        final lerpEp2 = vertex.lerpTo(OVertex(2, 4), 1.5);
+        expect(lerpEp2.x, 2.5);
+        expect(lerpEp2.y, 5.0);
+      });
+    });
+
     group('negate', () {
       test('negate', () {
         final vertex = OVertex(1, 2);
@@ -122,7 +98,7 @@ void main() {
     group('plus', () {
       test('plus', () {
         final vertex = OVertex(1, 2);
-        final added = vertex + const ui.Offset(1, 2);
+        final added = vertex + OVertex(1, 2);
         expect(added.x, 2.0);
         expect(added.y, 4.0);
       });
@@ -131,7 +107,7 @@ void main() {
     group('minus', () {
       test('minus', () {
         final vertex = OVertex(1, 2);
-        final subtracted = vertex - const ui.Offset(1, 2);
+        final subtracted = vertex - OVertex(1, 2);
         expect(subtracted.x, 0.0);
         expect(subtracted.y, 0.0);
       });
@@ -147,39 +123,349 @@ void main() {
     });
   });
 
-  group('Vector2 To OVertex', () {
-    test('toOVertex', () {
-      final vector = const ui.Offset(1, 2);
-      final vertex = vector.toOVertex(
-        northCp: const ui.Offset(1, 2),
-        eastCp: const ui.Offset(1, 2),
-        southCp: const ui.Offset(1, 2),
-        westCp: const ui.Offset(1, 2),
-      );
-      expect(vertex.x, 1.0);
-      expect(vertex.y, 2.0);
-      expect(vertex.northCp, const ui.Offset(1, 2));
-      expect(vertex.eastCp, const ui.Offset(1, 2));
-      expect(vertex.southCp, const ui.Offset(1, 2));
-      expect(vertex.westCp, const ui.Offset(1, 2));
+  group('$BezierOVertex', () {
+    group('constructors', () {
+      test('BezierOVertex', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+        );
+
+        expect(vertex.x, 1.0);
+        expect(vertex.y, 2.0);
+        expect(vertex.north, OVertex(1, 2));
+        expect(vertex.east, OVertex(1, 2));
+        expect(vertex.south, null);
+        expect(vertex.west, null);
+      });
+
+      test('BezierOVertex.zero', () {
+        final vertex = BezierOVertex.zero();
+        expect(vertex.x, 0.0);
+        expect(vertex.y, 0.0);
+        expect(vertex.north, null);
+        expect(vertex.east, null);
+        expect(vertex.south, null);
+        expect(vertex.west, null);
+      });
+
+      test('BezierOVertex.all', () {
+        final vertex = BezierOVertex.all(1);
+        expect(vertex.x, 1.0);
+        expect(vertex.y, 1.0);
+        expect(vertex.north, null);
+        expect(vertex.east, null);
+        expect(vertex.south, null);
+        expect(vertex.west, null);
+      });
+
+      test('BezierOVertex.offset', () {
+        final vertex = BezierOVertex.offset(
+          const Offset(1, 2),
+          west: OVertex(2, 1),
+          south: OVertex(2, 1),
+        );
+
+        expect(vertex.x, 1.0);
+        expect(vertex.y, 2.0);
+        expect(vertex.north, null);
+        expect(vertex.east, null);
+        expect(vertex.south, OVertex(2, 1));
+        expect(vertex.west, OVertex(2, 1));
+      });
+
+      test('BezierOVertex.oVertex', () {
+        final vertex = BezierOVertex.oVertex(
+          OVertex(1, 2),
+          west: OVertex(2, 1),
+          south: OVertex(2, 1),
+        );
+
+        expect(vertex.x, 1.0);
+        expect(vertex.y, 2.0);
+        expect(vertex.north, null);
+        expect(vertex.east, null);
+        expect(vertex.south, OVertex(2, 1));
+        expect(vertex.west, OVertex(2, 1));
+      });
+
+      test('BezierOVertex.copy', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+        );
+
+        final copy = BezierOVertex.copy(vertex);
+        expect(copy.x, 1.0);
+        expect(copy.y, 2.0);
+        expect(copy.north, OVertex(1, 2));
+        expect(copy.east, OVertex(1, 2));
+        expect(copy.south, null);
+        expect(copy.west, null);
+      });
+    });
+
+    group('equals', () {
+      test('==', () {
+        final vertex1 = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(2, 2),
+          south: OVertex(1, 1),
+          west: OVertex(2, 1),
+        );
+
+        final vertex2 = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(2, 2),
+          south: OVertex(1, 1),
+          west: OVertex(2, 1),
+        );
+
+        expect(vertex1, vertex2);
+      });
+
+      test('!=', () {
+        final vertex1 = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(2, 2),
+          south: OVertex(1, 1),
+          west: OVertex(2, 1),
+        );
+
+        final vertex2 = BezierOVertex(
+          2,
+          1,
+          north: OVertex(2, 1),
+          east: OVertex(1, 1),
+          south: OVertex(2, 2),
+          west: OVertex(1, 2),
+        );
+
+        expect(vertex1, isNot(vertex2));
+      });
+    });
+
+    group('clone', () {
+      test('clone', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        final clone = vertex.clone();
+        expect(clone, vertex);
+        expect(clone, isNot(same(vertex)));
+      });
+    });
+
+    group('toOVertex', () {
+      test('toOVertex', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        final oVertex = vertex.toOVertex();
+        expect(oVertex.x, 1.0);
+        expect(oVertex.y, 2.0);
+      });
+    });
+
+    group('lerpTo', () {
+      test('lerpTo', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        final lerp = vertex.lerpTo(
+          BezierOVertex(
+            2,
+            4,
+            north: OVertex(2, 4),
+            east: OVertex(2, 4),
+            south: OVertex(2, 4),
+            west: OVertex(2, 4),
+          ),
+          0.5,
+        );
+
+        expect(lerp.x, 1.5);
+        expect(lerp.y, 3.0);
+        expect(lerp.north, OVertex(1.5, 3));
+        expect(lerp.east, OVertex(1.5, 3));
+        expect(lerp.south, OVertex(1.5, 3));
+        expect(lerp.west, OVertex(1.5, 3));
+
+        final lerpEp1 = vertex.lerpTo(
+          BezierOVertex(
+            2,
+            4,
+            north: OVertex(2, 4),
+            east: OVertex(2, 4),
+            south: OVertex(2, 4),
+            west: OVertex(2, 4),
+          ),
+          -0.5,
+        );
+
+        expect(lerpEp1.x, 0.5);
+        expect(lerpEp1.y, 1.0);
+        expect(lerpEp1.north, OVertex(0.5, 1));
+        expect(lerpEp1.east, OVertex(0.5, 1));
+        expect(lerpEp1.south, OVertex(0.5, 1));
+        expect(lerpEp1.west, OVertex(0.5, 1));
+
+        final lerpEp2 = vertex.lerpTo(
+          BezierOVertex(
+            2,
+            4,
+            north: OVertex(2, 4),
+            east: OVertex(2, 4),
+            south: OVertex(2, 4),
+            west: OVertex(2, 4),
+          ),
+          1.5,
+        );
+
+        expect(lerpEp2.x, 2.5);
+        expect(lerpEp2.y, 5.0);
+        expect(lerpEp2.north, OVertex(2.5, 5));
+        expect(lerpEp2.east, OVertex(2.5, 5));
+        expect(lerpEp2.south, OVertex(2.5, 5));
+        expect(lerpEp2.west, OVertex(2.5, 5));
+      });
+    });
+
+    group('negate', () {
+      test('negate', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        final negated = -vertex;
+        expect(negated.x, -1.0);
+        expect(negated.y, -2.0);
+        expect(negated.north, OVertex(-1, -2));
+        expect(negated.east, OVertex(-1, -2));
+        expect(negated.south, OVertex(-1, -2));
+        expect(negated.west, OVertex(-1, -2));
+      });
+    });
+
+    group('plus', () {
+      test('plus', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        final added = vertex + BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        expect(added.x, 2.0);
+        expect(added.y, 4.0);
+        expect(added.north, OVertex(2, 4));
+        expect(added.east, OVertex(2, 4));
+        expect(added.south, OVertex(2, 4));
+        expect(added.west, OVertex(2, 4));
+      });
+    });
+
+    group('minus', () {
+      test('minus', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        final subtracted = vertex - BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        expect(subtracted.x, 0.0);
+        expect(subtracted.y, 0.0);
+        expect(subtracted.north, OVertex(0, 0));
+        expect(subtracted.east, OVertex(0, 0));
+        expect(subtracted.south, OVertex(0, 0));
+        expect(subtracted.west, OVertex(0, 0));
+      });
+    });
+
+    group('multiply', () {
+      test('multiply', () {
+        final vertex = BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(1, 2),
+          south: OVertex(1, 2),
+          west: OVertex(1, 2),
+        );
+
+        final scaled = vertex * 2;
+        expect(scaled.x, 2.0);
+        expect(scaled.y, 4.0);
+        expect(scaled.north, OVertex(2, 4));
+        expect(scaled.east, OVertex(2, 4));
+        expect(scaled.south, OVertex(2, 4));
+        expect(scaled.west, OVertex(2, 4));
+      });
     });
   });
 
   group('Offset To OVertex', () {
     test('toOVertex', () {
       const offset = Offset(1, 2);
-      final vertex = offset.toOVertex(
-        northCp: const ui.Offset(1, 2),
-        eastCp: const ui.Offset(1, 2),
-        southCp: const ui.Offset(1, 2),
-        westCp: const ui.Offset(1, 2),
-      );
+      final vertex = offset.toOVertex();
       expect(vertex.x, 1.0);
       expect(vertex.y, 2.0);
-      expect(vertex.northCp, const ui.Offset(1, 2));
-      expect(vertex.eastCp, const ui.Offset(1, 2));
-      expect(vertex.southCp, const ui.Offset(1, 2));
-      expect(vertex.westCp, const ui.Offset(1, 2));
     });
   });
 
@@ -197,22 +483,25 @@ void main() {
     });
   });
 
-  group('Bezierize OVertex', () {
-    test('bezierize', () {
+  group('BezierizeOVertex', () {
+    test('bezier', () {
       final vertex = OVertex(1, 2).bezier(
-        north: OVertex.offset(const ui.Offset(1, 2)),
-        east: OVertex.offset(const ui.Offset(1, 2)),
-        south: OVertex.offset(const ui.Offset(1, 2)),
-        west: OVertex.offset(const ui.Offset(1, 2)),
+        north: OVertex(1, 2),
+        east: OVertex(2, 2),
+        south: OVertex(1, 1),
+        west: OVertex(2, 1),
       );
 
       expect(
         vertex,
-        OVertex(1, 2)
-          ..northCp = const ui.Offset(1, 2)
-          ..eastCp = const ui.Offset(1, 2)
-          ..southCp = const ui.Offset(1, 2)
-          ..westCp = const ui.Offset(1, 2),
+        BezierOVertex(
+          1,
+          2,
+          north: OVertex(1, 2),
+          east: OVertex(2, 2),
+          south: OVertex(1, 1),
+          west: OVertex(2, 1),
+        ),
       );
     });
   });

--- a/flutter/mesh/test/src/data/overtex_test.dart
+++ b/flutter/mesh/test/src/data/overtex_test.dart
@@ -391,14 +391,15 @@ void main() {
           west: OVertex(1, 2),
         );
 
-        final added = vertex + BezierOVertex(
-          1,
-          2,
-          north: OVertex(1, 2),
-          east: OVertex(1, 2),
-          south: OVertex(1, 2),
-          west: OVertex(1, 2),
-        );
+        final added = vertex +
+            BezierOVertex(
+              1,
+              2,
+              north: OVertex(1, 2),
+              east: OVertex(1, 2),
+              south: OVertex(1, 2),
+              west: OVertex(1, 2),
+            );
 
         expect(added.x, 2.0);
         expect(added.y, 4.0);
@@ -420,14 +421,15 @@ void main() {
           west: OVertex(1, 2),
         );
 
-        final subtracted = vertex - BezierOVertex(
-          1,
-          2,
-          north: OVertex(1, 2),
-          east: OVertex(1, 2),
-          south: OVertex(1, 2),
-          west: OVertex(1, 2),
-        );
+        final subtracted = vertex -
+            BezierOVertex(
+              1,
+              2,
+              north: OVertex(1, 2),
+              east: OVertex(1, 2),
+              south: OVertex(1, 2),
+              west: OVertex(1, 2),
+            );
 
         expect(subtracted.x, 0.0);
         expect(subtracted.y, 0.0);

--- a/flutter/mesh/test/src/data/overtex_test.dart
+++ b/flutter/mesh/test/src/data/overtex_test.dart
@@ -8,8 +8,8 @@ void main() {
     group('constructors', () {
       test('OVertex.zero', () {
         final vertex = OVertex.zero();
-        expect(vertex.dx, 0.0);
-        expect(vertex.dy, 0.0);
+        expect(vertex.x, 0.0);
+        expect(vertex.y, 0.0);
         expect(vertex.northCp, isNull);
         expect(vertex.eastCp, isNull);
         expect(vertex.southCp, isNull);
@@ -18,8 +18,8 @@ void main() {
 
       test('OVertex', () {
         final vertex = OVertex(1, 2);
-        expect(vertex.dx, 1.0);
-        expect(vertex.dy, 2.0);
+        expect(vertex.x, 1.0);
+        expect(vertex.y, 2.0);
         expect(vertex.northCp, isNull);
         expect(vertex.eastCp, isNull);
         expect(vertex.southCp, isNull);
@@ -28,8 +28,8 @@ void main() {
 
       test('OVertex.offset', () {
         final vertex = OVertex.offset(const Offset(1, 2));
-        expect(vertex.dx, 1.0);
-        expect(vertex.dy, 2.0);
+        expect(vertex.x, 1.0);
+        expect(vertex.y, 2.0);
         expect(vertex.northCp, isNull);
         expect(vertex.eastCp, isNull);
         expect(vertex.southCp, isNull);
@@ -38,8 +38,8 @@ void main() {
 
       test('OVertex.all', () {
         final vertex = OVertex.all(1);
-        expect(vertex.dx, 1.0);
-        expect(vertex.dy, 1.0);
+        expect(vertex.x, 1.0);
+        expect(vertex.y, 1.0);
         expect(vertex.northCp, isNull);
         expect(vertex.eastCp, isNull);
         expect(vertex.southCp, isNull);
@@ -49,8 +49,8 @@ void main() {
       test('OVertex.copy', () {
         final vertex = OVertex(1, 2);
         final copy = OVertex.copy(vertex);
-        expect(copy.dx, 1.0);
-        expect(copy.dy, 2.0);
+        expect(copy.x, 1.0);
+        expect(copy.y, 2.0);
         expect(copy.northCp, isNull);
         expect(copy.eastCp, isNull);
         expect(copy.southCp, isNull);
@@ -114,8 +114,8 @@ void main() {
       test('negate', () {
         final vertex = OVertex(1, 2);
         final negated = -vertex;
-        expect(negated.dx, -1.0);
-        expect(negated.dy, -2.0);
+        expect(negated.x, -1.0);
+        expect(negated.y, -2.0);
       });
     });
 
@@ -123,8 +123,8 @@ void main() {
       test('plus', () {
         final vertex = OVertex(1, 2);
         final added = vertex + const ui.Offset(1, 2);
-        expect(added.dx, 2.0);
-        expect(added.dy, 4.0);
+        expect(added.x, 2.0);
+        expect(added.y, 4.0);
       });
     });
 
@@ -132,8 +132,8 @@ void main() {
       test('minus', () {
         final vertex = OVertex(1, 2);
         final subtracted = vertex - const ui.Offset(1, 2);
-        expect(subtracted.dx, 0.0);
-        expect(subtracted.dy, 0.0);
+        expect(subtracted.x, 0.0);
+        expect(subtracted.y, 0.0);
       });
     });
 
@@ -141,8 +141,8 @@ void main() {
       test('multiply', () {
         final vertex = OVertex(1, 2);
         final scaled = vertex * 2;
-        expect(scaled.dx, 2.0);
-        expect(scaled.dy, 4.0);
+        expect(scaled.x, 2.0);
+        expect(scaled.y, 4.0);
       });
     });
   });
@@ -156,8 +156,8 @@ void main() {
         southCp: const ui.Offset(1, 2),
         westCp: const ui.Offset(1, 2),
       );
-      expect(vertex.dx, 1.0);
-      expect(vertex.dy, 2.0);
+      expect(vertex.x, 1.0);
+      expect(vertex.y, 2.0);
       expect(vertex.northCp, const ui.Offset(1, 2));
       expect(vertex.eastCp, const ui.Offset(1, 2));
       expect(vertex.southCp, const ui.Offset(1, 2));
@@ -174,8 +174,8 @@ void main() {
         southCp: const ui.Offset(1, 2),
         westCp: const ui.Offset(1, 2),
       );
-      expect(vertex.dx, 1.0);
-      expect(vertex.dy, 2.0);
+      expect(vertex.x, 1.0);
+      expect(vertex.y, 2.0);
       expect(vertex.northCp, const ui.Offset(1, 2));
       expect(vertex.eastCp, const ui.Offset(1, 2));
       expect(vertex.southCp, const ui.Offset(1, 2));


### PR DESCRIPTION
## Description

Some of the changes on #10 modified some of the public API.

This pr addressed some of my concerns. In detail: 

###  Keep `vector_math` out

One less dependency is welcome. Especially one that has a pinned version on Flutter. 

While keeping `OVertex` as a modifiable vertex class, not extending `Vector2` frees us from that inextensible hell that is `Vector2`'s interface (all factory constructors making subclassing almost impossible). 

Package users that relied on that inheritance will have to convert instance classes manually:
```dart
final myOVertex = OVertex(myVector2.x, myVector2.y)
```

### Introducing `BezierOVertex`

Not using `Vector2` as a superclass of `OVertex` allowed us to subclass `OVertex` without copying tons of code. This allowed me to split  `OVertex` from the bezier control points. The bezier control points are a concern on their own (eg: before this change, the control points are also an `OVertex`, wich could receive control points. Control points with control points make no sense). 

We may also explore non-rectangular meshes in the future.  The concept or North, South, West, and East would make no sense in those scenarios. 

Package users may declare `BezierOVertex` directly or use the shorthands that were not changed:
```dart
final myBezierOVertex = (0.0, 0.0).v.bezier(north: (0.0, 0.0).v)
```

### Lerping OVertex

Linear interpolation between bezier and non-bezier vertices was not quite supported before, the situation remains the same. 