### PR TITLE
feat: add example use of OMeshGradient with WidgetMask

### DIFF
--- a/flutter/mesh/example/lib/examples/masking.dart
+++ b/flutter/mesh/example/lib/examples/masking.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:mesh/mesh.dart';
+import 'package:mix/mix.dart';
+import 'package:widget_mask/widget_mask.dart';
+
+class MaskingUsage extends StatelessWidget {
+  const MaskingUsage({super.key});
+
+  static const String code = '''
+    WidgetMask(
+      blendMode: BlendMode.dstATop,
+      mask: Center(child: Text('Mesh Gradient')), // your mask
+      child: OMeshGradient(
+        addRepaintBoundary: false, // set this to false
+        ...
+      )
+    )
+''';
+
+  @override
+  Widget build(BuildContext context) {
+    return WidgetMask(
+      blendMode: BlendMode.dstATop,
+      mask: Center(
+        child: Box(
+          style: Style(
+            $box.padding(0, 10, 30),
+            $text.textAlign(TextAlign.center),
+            $text.style(
+              color: Colors.white,
+              fontSize: 84,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          child: const StyledText('Mesh\nGradient'),
+        ),
+      ),
+      child: SizedBox(
+        height: 500,
+        child: OMeshGradient(
+          tessellation: 30,
+          addRepaintBoundary: false,
+          mesh: OMeshRect(
+            width: 3,
+            height: 3,
+            vertices: [
+              (-0.06, -0.08).v,
+              (0.58, -0.05).v,
+              (1.36, 0.04).v, // Row 1
+
+              (-0.02, 0.31).v,
+              (0.44, 0.63).v,
+              (1.11, 0.4).v, // Row 2
+
+              (-0.01, 1.01).v,
+              (1.01, 1.0).v,
+              (1.02, 0.73).v, // Row 3
+            ],
+            colors: const [
+              Color(0xffa52b68),
+              Color(0xff4693a9),
+              Color(0xff4693a9), // Row 1
+
+              Color(0xffa52ba0),
+              Color(0xffe8dad4),
+              Color(0xff4693a9), // Row 2
+
+              Color(0xff9715a9),
+              Color(0xff4693a9),
+              Color(0xff4693a9), // Row 3
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/mesh/example/lib/main.dart
+++ b/flutter/mesh/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:example/examples/advanced.dart';
 import 'package:example/examples/basic.dart';
 import 'package:example/examples/custom_animation.dart';
 import 'package:example/examples/instrinsic_animation.dart';
+import 'package:example/examples/masking.dart';
 import 'package:flutter/material.dart';
 import 'package:mix/mix.dart';
 import 'package:syntax_highlight/syntax_highlight.dart';
@@ -44,6 +45,12 @@ More advanced example with different colors in each vertex, bezier vertices and 
     description: '''
 An example to illustrate animation from an animation controller.''',
     code: CustomAnimation.code,
+  ),
+  masking(
+    view: MaskingUsage(),
+    title: 'Masking Usage',
+    description: 'A simple example how to apply WidgetMask to OMeshGradient',
+    code: MaskingUsage.code,
   ),
   ;
 
@@ -96,7 +103,7 @@ class _MainState extends State<Main> {
                 style: Style(
                   $box.alignment.center(),
                   $box.width(145),
-                  $box.maxHeight(150),
+                  $box.maxHeight(180),
                   $box.borderRadius.topRight(16),
                   $box.borderRadius.bottomRight(16),
                   $box.padding(8),

--- a/flutter/mesh/example/pubspec.yaml
+++ b/flutter/mesh/example/pubspec.yaml
@@ -13,5 +13,6 @@ dependencies:
   mix: ^1.4.4
   syntax_highlight: ^0.4.0
   url_launcher: ^6.3.0
+  widget_mask: ^1.0.0+0
 
 flutter:


### PR DESCRIPTION
## Description

Hello 👋 

First off, thank you for the amazing `mesh` package—it’s been incredibly helpful for exploring creative UI effects.

In this PR, I’ve added an example demonstrating how to mask a mesh gradient with arbitrary text using the `widget_mask` package.

<img width="1378" alt="Screenshot 2025-01-23 at 12 12 50" src="https://github.com/user-attachments/assets/44eccadf-a365-4316-98a1-9569389e4b09" />

## (Required) Link to the issue

I’m not sure if there’s an existing issue for this, but I’ve been experimenting to find the best way to achieve this effect. Setting `addRepaintBoundary` to false seems like it could impact performance, but it might be the necessary tradeoff 🤷. Ideally, this could be achieved without using an extra package—perhaps with a `ShaderMask`—but I’m unsure how that would work in conjunction with `OMeshRectPaint`.

Any insights or suggestions would be greatly appreciated! Feel free to merge or discard this PR—hopefully it's valuable to someone in the future.